### PR TITLE
Added importTester

### DIFF
--- a/enforce_codeowners/keras_bot/importTester.py
+++ b/enforce_codeowners/keras_bot/importTester.py
@@ -1,0 +1,122 @@
+import os
+from glob import glob
+
+ignore = ['__future__', 'collections', 'random', 'six', 'cPickle', 'scipy', 'hashlib', 
+            'io', 'contextlib', 'unittest', 'types', 'h5py', 'inspect', 'tarfile', 'yaml', 
+            'copy', 'marshal', 'requests', 'functools', 'gzip', 're', 'Queue', 'queue', 
+            'os', 'pickle', 'importlib', 'mock', 'threading', 'codecs', 'tempfile', 'time', 
+            'binascii', 'pydot', 'zipfile', 'json', 'shutil', 'abc', 'sys', 'csv', 'cntk',
+            'warnings', 'numpy', 'skimage', 'multiprocessing', 'distutils', 'tensorflow', 
+            'theano', 'keras_applications', "keras_preprocessing"]
+
+def check_absolute(file):
+    
+    with open(file) as f:
+        imports = f.read().split("\n")
+
+    errs = []
+    lineno=0
+
+    comment = False
+
+    for line in imports:
+        lineno+=1
+        #Ingore lines withing multi line comments
+        if '\"\"\"' in line:
+            comment = not comment
+        #Empty line or comment line
+        if line == "" or comment == True or '#' in line:
+            pass
+        else:
+            split_line = line.split()
+            #Import
+            if split_line[0] == 'import':
+                module_split = split_line[1].split('.')
+                #Check if module is an ignored library
+                if module_split[0] in ignore:
+                    pass 
+
+            #ImportFrom
+            elif split_line[0] == 'from' and len(split_line) >= 3:
+                #Check if module is an ignored library or line doesnt contain import
+                if split_line[1] in ignore or split_line[2] != 'import':
+                    pass
+                #Check if import is absolute or relative
+                elif split_line[1].startswith('.'):
+                    string = str(file) + " contains a relative import on line " + str(lineno)
+                    errs.append(string)
+                else:
+                    module_split = split_line[1].split('.')
+                    if module_split[0] in ignore:
+                        continue
+
+    return errs
+
+def check_relative(file):
+    
+    with open(file) as f:
+        imports = f.read().split("\n")
+
+    errs = []
+    lineno=0
+
+    comment = False
+
+    for line in imports:
+        lineno+=1
+        #Ingore lines withing multi line comments
+        if '\"\"\"' in line:
+            comment = not comment
+        #Empty line or comment line
+        if line == "" or comment == True or '#' in line:
+            pass
+        else:
+            split_line = line.split()
+            #Import
+            if split_line[0] == 'import':
+                module_split = split_line[1].split('.')
+                #Check if module is an ignored library
+                if module_split[0] in ignore:
+                    continue
+                else:
+                    string = str(file) + " contains an absolute import on line " + str(lineno)
+                    errs.append(string)
+
+            #ImportFrom
+            elif split_line[0] == 'from' and len(split_line) >= 3:
+                #Check if module is an ignored library or line doesnt contain import
+                if split_line[1] in ignore or split_line[2] != 'import':
+                    pass
+                #Check if import is absolute or relative
+                elif split_line[1].startswith('.'):
+                    pass
+                else:
+                    module_split = split_line[1].split('.')
+                    if module_split[0] in ignore:
+                        continue
+                    else:
+                        string = str(file) + " contains a relative import on line " + str(lineno)
+                        errs.append(string)
+
+    return errs
+
+def checkImports(dirPath, style):
+    ret = {}
+    result = [y for x in os.walk(dirPath) for y in glob(os.path.join(x[0], '*.py'))]
+    if style == "rel":
+        for file in result:
+            fileKey = file[11:]
+            val = check_relative(file)
+            if val == []:
+                pass
+            else:
+                ret[fileKey]=(val)
+    elif style == "abs":
+        for file in result:
+            fileKey = file[11:]
+            val = check_absolute(file)
+            if val == []:
+                pass
+            else:
+                ret[fileKey]=(val)
+    return ret

--- a/enforce_codeowners/keras_bot/import_tester.py
+++ b/enforce_codeowners/keras_bot/import_tester.py
@@ -52,71 +52,14 @@ def check_absolute(file):
 
     return errs
 
-def check_relative(file):
-    
-    with open(file) as f:
-        imports = f.read().split("\n")
-
-    errs = []
-    lineno=0
-
-    comment = False
-
-    for line in imports:
-        lineno+=1
-        #Ingore lines withing multi line comments
-        if '\"\"\"' in line:
-            comment = not comment
-        #Empty line or comment line
-        if line == "" or comment == True or '#' in line:
-            pass
-        else:
-            split_line = line.split()
-            #Import
-            if split_line[0] == 'import':
-                module_split = split_line[1].split('.')
-                #Check if module is an ignored library
-                if module_split[0] in ignore:
-                    continue
-                else:
-                    string = str(file) + " contains an absolute import on line " + str(lineno)
-                    errs.append(string)
-
-            #ImportFrom
-            elif split_line[0] == 'from' and len(split_line) >= 3:
-                #Check if module is an ignored library or line doesnt contain import
-                if split_line[1] in ignore or split_line[2] != 'import':
-                    pass
-                #Check if import is absolute or relative
-                elif split_line[1].startswith('.'):
-                    pass
-                else:
-                    module_split = split_line[1].split('.')
-                    if module_split[0] in ignore:
-                        continue
-                    else:
-                        string = str(file) + " contains a relative import on line " + str(lineno)
-                        errs.append(string)
-
-    return errs
-
-def checkImports(dirPath, style):
+def check_imports(dirPath):
     ret = {}
     result = [y for x in os.walk(dirPath) for y in glob(os.path.join(x[0], '*.py'))]
-    if style == "rel":
-        for file in result:
-            fileKey = file[11:]
-            val = check_relative(file)
-            if val == []:
-                pass
-            else:
-                ret[fileKey]=(val)
-    elif style == "abs":
-        for file in result:
-            fileKey = file[11:]
-            val = check_absolute(file)
-            if val == []:
-                pass
-            else:
-                ret[fileKey]=(val)
+    for file in result:
+        fileKey = file[11:]
+        val = check_absolute(file)
+        if val == []:
+            pass
+        else:
+            ret[fileKey]=(val)
     return ret

--- a/enforce_codeowners/keras_bot/import_tester.py
+++ b/enforce_codeowners/keras_bot/import_tester.py
@@ -35,6 +35,10 @@ def check_absolute(file):
                 #Check if module is an ignored library
                 if module_split[0] in ignore:
                     pass 
+                else:
+                    string = str(file) + " contains an absolute import on line " + str(lineno)
+                    errs.append(string)
+                    
 
             #ImportFrom
             elif split_line[0] == 'from' and len(split_line) >= 3:
@@ -43,12 +47,14 @@ def check_absolute(file):
                     pass
                 #Check if import is absolute or relative
                 elif split_line[1].startswith('.'):
-                    string = str(file) + " contains a relative import on line " + str(lineno)
-                    errs.append(string)
+                    pass
                 else:
                     module_split = split_line[1].split('.')
                     if module_split[0] in ignore:
                         continue
+                    else:
+                        string = str(file) + " contains an absolute import on line " + str(lineno)
+                        errs.append(string)
 
     return errs
 

--- a/enforce_codeowners/keras_bot/pull_requests.py
+++ b/enforce_codeowners/keras_bot/pull_requests.py
@@ -2,7 +2,7 @@ import os
 
 import github
 
-import importTester
+import import_tester
 
 import shutil
 
@@ -43,19 +43,17 @@ The owner of those file is @{owner}
 """
 
     absKeys = list(additions['absolute'].keys())[:10]
-    relKeys = list(additions['relative'].keys())[:10]
 
-    absolute = "The following files should not contain relative imports\n"
-    for file in range(len(absKeys)):
-        absolute += absKeys[file] + "\n"
-    absolute += ("\nThis is " + str(file+1) + " out of " + len(additions['absolute']) + " files with relative imports to be changed\n")
-
-    relative = "The following files should not contain absolute imports\n"
-    for file in range(len(relKeys)):
-        relative += relKeys[file] + "\n"
-    relative += ("\nThis is " + str(file+1) + " out of " + " files with absolute imports to be changed\n")
+    if absKeys != []:
+        absolute = "The following files should not contain relative imports\n"
+        for file in range(len(absKeys)):
+            absolute += f'<details><summary>{absKeys[file]}</summary>'
+            for err in additions['absolute'][absKeys[file]]:
+                absolute+= err + "</br>"
+            absolute+="</details>"
+        absolute += (f"\nThis is {file+1} out of {len(additions['absolute'])} files with relative imports to be changed\n")
     
-    message += (absolute + "\n" + relative + "\n")
+        message += (absolute + "\n")
     
     message+="""@{owner} could you please take a look at it whenever 
 you have the time and add a review? Thank you in advance for the help.
@@ -102,13 +100,11 @@ def examine_single_pull_request(pull_request, map_path_owner):
 
     os.system(cmd)
     
-    absoluteOnly = importTester.checkImports("./" + repo_id + "/keras", "abs")
-    relativeOnly = importTester.checkImports("./" + repo_id + "/tests", "rel")
+    absoluteOnly = import_tester.check_imports("./" + repo_id + "/keras")
     
     shutil.rmtree(repo_id)
     
     additions = {}
-    additions['relative'] = relativeOnly
     additions['absolute'] = absoluteOnly
     
 


### PR DESCRIPTION
This PR contains additions to the `pull_request.py` as well as an additional script `importTester.py`. 

This PR introduces the testing of relative and absolute imports in the keras and tests directories. The message sent to the user has been edited to now receive an additional parameter (additions) which is the import testing. The message adds the first 10 files with errors for both absolute and relative (20 total), and specifies how many remain eg. 10/56. This is done by cloning the users repo, parsing the files, then deleting the cloned repo.

Please let me know if you have any questions or concerns.